### PR TITLE
Fix dependency name in requirements.txt, and make usage error more readable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ youtube-dl
 imageio
 moviepy
 ffmpy
-python-imaging
+Pillow

--- a/voc_convert.py
+++ b/voc_convert.py
@@ -318,8 +318,8 @@ def write_txt_files(dest_dir, train_xml_annots, val_xml_annots):
 if __name__ == '__main__':
 
   assert(len(sys.argv) == 8), \
-    ["Usage: python voc_convert.py [VID_SOURCE] [DSET_DEST] [NUM_THREADS]",
-     "[NUM_TRAIN] [NUM_VAL] [MAX_RATIO] [INCL_ABS]"]
+    "Usage: python voc_convert.py [VID_SOURCE] [DSET_DEST] [NUM_THREADS] " \
+    "[NUM_TRAIN] [NUM_VAL] [MAX_RATIO] [INCL_ABS]"
   src_dir          = sys.argv[1]+'/'
   dest_dir         = sys.argv[2]+'/'
   num_threads      = int(sys.argv[3])


### PR DESCRIPTION
The command-line usage error used to look like this:

```
$ python3 voc_convert.py
Traceback (most recent call last):
  File "voc_convert.py", line 322, in <module>
    "[NUM_TRAIN] [NUM_VAL] [MAX_RATIO] [INCL_ABS]"]
AssertionError: ['Usage: python voc_convert.py [VID_SOURCE] [DSET_DEST] [NUM_THREADS]', '[NUM_TRAIN] [NUM_VAL] [MAX_RATIO] [INCL_ABS]']
```

Now it is a little easier to understand. :smiley:

```
$ python3 voc_convert.py
Traceback (most recent call last):
  File "voc_convert.py", line 321, in <module>
    "Usage: python voc_convert.py [VID_SOURCE] [DSET_DEST] [NUM_THREADS] " \
AssertionError: Usage: python voc_convert.py [VID_SOURCE] [DSET_DEST] [NUM_THREADS] [NUM_TRAIN] [NUM_VAL] [MAX_RATIO] [INCL_ABS]
```